### PR TITLE
Fix appearance when cancel tracking is called

### DIFF
--- a/Sources/Slider.swift
+++ b/Sources/Slider.swift
@@ -348,6 +348,8 @@ open class Slider : UIControl {
         updateValueViewText()
         didEndTracking?(self)
         updateValueViewColor()
+        updateValueViewBorderColor()
+        updateValueViewTextColor()
     }
     
     private func boundsForValueViewCenter() -> CGRect {


### PR DESCRIPTION
Fix for when the user tries to scroll a table/collection view which cells contain a Slider. When the user tries to scroll the ScrollView beyond it's content size (causing the bounce effect), sometimes the Slider gets a call to Slider.beginTracking, followed by a Slider.cancelTracking. Since the body of Slider.cancelTracking only calls updateValueViewColor(), sometimes the ValueView textcolor ends up the same as it's background color, in which case the text becomes invisible.